### PR TITLE
feat: implement user registration with password hashing and user store interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.envrc
+.env
+bin
+tmp
+ecom

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -24,7 +24,8 @@ func NewAPIServer(addr string, db *sql.DB) *APIserver {
 func (s *APIserver) Run() error {
 	router := mux.NewRouter()
 	subrouter := router.PathPrefix("api/v1/").Subrouter()
-	userHandler := user.NewHandler()
+	userStore := user.NewStore(s.db)
+	userHandler := user.NewHandler(userStore)
 	userHandler.RegisterRoutes(subrouter)
 	log.Println("Listening on", s.addr)
 	return http.ListenAndServe(s.addr, router)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24.0
 
 require github.com/gorilla/mux v1.8.1
 
+require golang.org/x/crypto v0.38.0 // indirect
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.2

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=

--- a/service/auth/password.go
+++ b/service/auth/password.go
@@ -1,0 +1,13 @@
+package auth
+
+import "golang.org/x/crypto/bcrypt"
+
+func HashedPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+
+	if err != nil {
+		return "", nil
+	}
+
+	return string(hash), nil
+}

--- a/service/user/routes.go
+++ b/service/user/routes.go
@@ -1,18 +1,23 @@
 package user
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/Code-Linx/Go-Ecommerce-Backend-Api/service/auth"
 	"github.com/Code-Linx/Go-Ecommerce-Backend-Api/types"
 	"github.com/Code-Linx/Go-Ecommerce-Backend-Api/utils"
 	"github.com/gorilla/mux"
 )
 
 type Handler struct {
+	store types.UserStore
 }
 
-func NewHandler() *Handler {
-	return &Handler{}
+func NewHandler(store types.UserStore) *Handler {
+	return &Handler{
+		store: store,
+	}
 }
 
 func (h *Handler) RegisterRoutes(router *mux.Router) {
@@ -22,7 +27,6 @@ func (h *Handler) RegisterRoutes(router *mux.Router) {
 }
 
 func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {}
-
 
 func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 
@@ -34,4 +38,31 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//check if user exist
+	_, err := h.store.GetUserByEmail(payload.Email)
+	if err == nil {
+		utils.WriteError(w, http.StatusBadRequest, fmt.Errorf("user with email %s already exist", payload.Email))
+		return
+	}
+
+	//if it doesnt exist we create the new user
+
+	hashedPassword, err := auth.HashedPassword(payload.Password)
+	if err != nil {
+		utils.WriteError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	err = h.store.CreateUser(types.User{
+		FirstName: payload.FirstName,
+		LastName:  payload.LastName,
+		Email:     payload.Email,
+		Password:  hashedPassword,
+	})
+
+	if err != nil {
+		utils.WriteError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	utils.WriteJson(w, http.StatusCreated, nil)
 }

--- a/service/user/stores.go
+++ b/service/user/stores.go
@@ -11,6 +11,10 @@ type Store struct {
 	db *sql.DB
 }
 
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
 func (s *Store) GetUserByEmail(email string) (*types.User, error) {
 	rows, err := s.db.Query("SELECT * FROM users WHERE email = ?", email)
 	if err != nil {
@@ -35,7 +39,7 @@ func scanRowIntoUser(rows *sql.Rows) (*types.User, error) {
 	user := new(types.User)
 	err := rows.Scan(
 		&user.ID,
-		&user.FisrtName,
+		&user.FirstName,
 		&user.LastName,
 		&user.Email,
 		&user.Password,
@@ -47,4 +51,12 @@ func scanRowIntoUser(rows *sql.Rows) (*types.User, error) {
 	}
 
 	return user, nil
+}
+
+func (s *Store) GetUserByID(id int) (*types.User, error) {
+
+}
+
+func (s *Store) CreateUser(user types.User) error {
+
 }

--- a/types/types.go
+++ b/types/types.go
@@ -2,9 +2,15 @@ package types
 
 import "time"
 
+type UserStore interface {
+	GetUserByEmail(email string) (*User, error)
+	GetUserByID(id int) (*User, error)
+	CreateUser(User) error
+}
+
 type User struct {
 	ID        int       `json:"id"`
-	FisrtName string    `json:"firstName"`
+	FirstName string    `json:"firstName"`
 	LastName  string    `json:"lastName"`
 	Email     string    `json:"email"`
 	Password  string    `json:"-"`
@@ -12,7 +18,7 @@ type User struct {
 }
 
 type RegisterUserPayload struct {
-	FisrtName string `json:"firstName"`
+	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
 	Email     string `json:"email"`
 	Password  string `json:"password"`


### PR DESCRIPTION
- Added `NewStore` constructor and `UserStore` interface to define user storage behavior.
- Introduced `GetUserByID` and `CreateUser` method stubs to `Store`.
- Updated `APIserver.Run()` to inject `UserStore` into `Handler`.
- Created `auth/password.go` with bcrypt-based `HashedPassword` utility.
- Enhanced `handleRegister` logic to:
  - Parse request body
  - Check for existing user by email
  - Hash password
  - Create new user in DB
